### PR TITLE
Add driver for Bun.sql API

### DIFF
--- a/src/driver.ts
+++ b/src/driver.ts
@@ -1,4 +1,5 @@
 export {connect as 'better-sqlite3'} from './driver/better-sqlite3.ts'
+export {connect as 'bun'} from './driver/bun-sql.ts'
 export {connect as 'bun:sqlite'} from './driver/bun-sqlite.ts'
 export {connect as 'd1'} from './driver/d1.ts'
 export {connect as '@libsql/client'} from './driver/libsql.ts'

--- a/src/driver/bun-sql.ts
+++ b/src/driver/bun-sql.ts
@@ -1,0 +1,113 @@
+import type {SQL} from 'bun'
+import {AsyncDatabase, type TransactionOptions} from '../core/Database.ts'
+import type {
+  AsyncDriver,
+  AsyncStatement,
+  BatchedQuery,
+  PrepareOptions
+} from '../core/Driver.ts'
+import {mysqlDialect} from '../mysql/dialect.ts'
+import {mysqlDiff} from '../mysql/diff.ts'
+import {setTransaction as setMysqlTransaction} from '../mysql/transactions.ts'
+import {postgresDialect} from '../postgres/dialect.ts'
+import {postgresDiff} from '../postgres/diff.ts'
+import {setTransaction as setPostgresTransaction} from '../postgres/transactions.ts'
+import {sqliteDialect} from '../sqlite.ts'
+import {sqliteDiff} from '../sqlite/diff.ts'
+
+class PreparedStatement implements AsyncStatement {
+  constructor(
+    private client: SQL,
+    private sql: string
+  ) {}
+
+  all(params: Array<unknown>): Promise<Array<object>> {
+    return this.client.unsafe(this.sql, params)
+  }
+
+  async run(params: Array<unknown>) {
+    await this.client.unsafe(this.sql, params)
+  }
+
+  get(params: Array<unknown>): Promise<object> {
+    return this.all(params).then(rows => rows[0] ?? null)
+  }
+
+  values(params: Array<unknown>): Promise<Array<Array<unknown>>> {
+    return this.client.unsafe(this.sql, params).values()
+  }
+
+  free() {}
+}
+
+export class BunSqlDriver implements AsyncDriver {
+  parsesJson = true
+  supportsTransactions = true
+
+  constructor(
+    private client: SQL,
+    private dialect: 'postgres' | 'mysql' | 'sqlite',
+    private depth = 0
+  ) {}
+
+  async exec(query: string) {
+    await this.client.unsafe(query)
+  }
+
+  prepare(sql: string, options?: PrepareOptions): PreparedStatement {
+    return new PreparedStatement(this.client, sql)
+  }
+
+  async close(): Promise<void> {
+    await this.client.close()
+  }
+
+  async batch(queries: Array<BatchedQuery>): Promise<Array<Array<unknown>>> {
+    return this.transaction(async tx => {
+      const results = []
+      for (const {sql, params} of queries)
+        results.push(await tx.prepare(sql).values(params))
+      return results
+    }, {})
+  }
+
+  async transaction<T>(
+    run: (inner: AsyncDriver) => Promise<T>,
+    options: TransactionOptions['postgres' | 'mysql' | 'sqlite']
+  ): Promise<T> {
+    if (this.depth > 0) {
+      try {
+        return await this.client.savepoint(async sp => {
+          return await run(new BunSqlDriver(sp as any, this.dialect, this.depth + 1))
+        }) as T
+      } catch (error) {
+        throw error
+      }
+    }
+    return await this.client.begin(async tx => {
+      if (this.dialect === 'postgres') {
+        const setTx = setPostgresTransaction(options as TransactionOptions['postgres'])
+        if (setTx) await tx.unsafe(setTx)
+      } else if (this.dialect === 'mysql') {
+        const setTx = setMysqlTransaction(options as TransactionOptions['mysql'])
+        if (setTx) await tx.unsafe(setTx)
+      }
+      return await run(new BunSqlDriver(tx as any, this.dialect, this.depth + 1))
+    }) as T
+  }
+}
+
+export function connect(
+  client: SQL,
+  dialect: 'postgres' | 'mysql' | 'sqlite'
+): AsyncDatabase<'postgres' | 'mysql' | 'sqlite'> {
+  const driver = new BunSqlDriver(client, dialect)
+  switch (dialect) {
+    case 'postgres':
+      return new AsyncDatabase(driver, postgresDialect, postgresDiff)
+    case 'mysql':
+      return new AsyncDatabase(driver, mysqlDialect, mysqlDiff)
+    case 'sqlite':
+      return new AsyncDatabase(driver, sqliteDialect, sqliteDiff)
+  }
+}

--- a/test/driver/bun-sql.test.ts
+++ b/test/driver/bun-sql.test.ts
@@ -1,0 +1,15 @@
+import {suite} from '@alinea/suite'
+import {testDriver} from '../TestDriver.ts'
+import {isBun} from '../TestRuntime.ts'
+
+await testDriver(suite(import.meta), async () => {
+  if (!isBun) return
+  const {bun: connect} = await import('@/driver.ts')
+  const {SQL} = await import('bun')
+  try {
+    const sql = new SQL('postgres://localhost:5432/test')
+    return connect(sql, 'postgres')
+  } catch (e) {
+    return undefined
+  }
+})


### PR DESCRIPTION
This change adds support for Bun's native SQL API (`Bun.sql`) through a new driver. 
The driver supports PostgreSQL, MySQL, and SQLite dialects, as requested.
It implements the `AsyncDriver` interface, handling query execution, prepared statements, and nested transactions using Bun's `.begin()` and `.savepoint()` methods.
The dialect is an explicit parameter in the `connect` function.

---
*PR created automatically by Jules for task [14496133303180769743](https://jules.google.com/task/14496133303180769743) started by @benmerckx*